### PR TITLE
Recon Operator 1.8.4: OpenAPI contracts + Playwright e2e

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,5 +68,36 @@ jobs:
 
       - name: Security checks
         run: |
-          bandit -q -ll -r . -x ./.venv,./test_autonmap.py,./test_decrypt.py,./test_kali_ai_scan.py,./test_recon_planner.py,./test_scan_engine.py,./test_state_store.py,./test_tool_inventory.py
+          bandit -q -ll -r . -x ./.venv,./test_autonmap.py,./test_decrypt.py,./test_kali_ai_scan.py,./test_recon_planner.py,./test_scan_engine.py,./test_state_store.py,./test_tool_inventory.py,./test_openapi_contract.py,./e2e
           pip-audit -r requirements.txt
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install nmap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y nmap
+
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -r requirements-dev.txt
+
+      - name: Install Playwright Chromium
+        run: python -m playwright install --with-deps chromium
+
+      - name: Dashboard browser smoke
+        env:
+          RUN_E2E: "1"
+        run: python -m unittest discover -s e2e -v

--- a/AUDIT_CHECKLIST.md
+++ b/AUDIT_CHECKLIST.md
@@ -180,7 +180,8 @@ Missing tools не устанавливались автоматически: э
 - [x] ~~Schedule multi-instance leader election (P1-03).~~
 - [ ] Full multi-tenant RBAC / UI accounts (token isolation only today).
 - [x] ~~Поднять `autonmap.py` coverage до ≥75% (~82%; overall ~78%; fail_under 75).~~
-- [ ] Добавить CI browser E2E + axe-core для keyboard/ARIA/responsive regressions.
+- [x] ~~CI browser E2E (Playwright dashboard smoke).~~ axe-core still open.
+- [x] ~~OpenAPI contract / route-parity tests.~~
 
 ### P2 — security и maintainability
 

--- a/IMPROVEMENT_PLAN.md
+++ b/IMPROVEMENT_PLAN.md
@@ -1,7 +1,7 @@
 # Recon Operator — полный план улучшений
 
 **Продукт:** Recon Operator (ранее Nmap Automator)  
-**Текущая версия кода:** 1.8.3  
+**Текущая версия кода:** 1.8.4  
 **Ветка:** `beta-hardening`  
 **Дата плана:** 2026-07-16  
 **Связанные файлы:** `AUDIT_CHECKLIST.md`, `README.md`, `SECURITY.md`
@@ -161,9 +161,9 @@
 | --- | --- | --- | ---: |
 | P1-10 | ~~Coverage `autonmap.py` ≥ 75%~~ | jobs, ownership, tools, planner, Telegram (~82%) | M |
 | P1-11 | ~~Overall coverage ≥ 75%, fail_under поднять~~ | `fail_under = 75` in pyproject (~78%) | S |
-| P1-12 | Browser E2E в CI (Playwright) | scan mock, history, a11y smoke | L |
+| P1-12 | ~~Browser E2E в CI (Playwright)~~ | `e2e/` dashboard smoke + CI job | L |
 | P1-13 | axe-core / accessibility regression | keyboard, ARIA, contrast | M |
-| P1-14 | OpenAPI contract tests | schemathesis или generated checks | M |
+| P1-14 | ~~OpenAPI contract tests~~ | route parity + schema shape (`test_openapi_contract.py`) | M |
 
 **Критерий done P1:** 2+ API tokens с изоляцией; rate-limit корректный при 2 workers; coverage gate 75%; E2E smoke в CI.
 
@@ -409,6 +409,7 @@
 | 2026-07-16 | 1.8.1 | P1-01 optional Redis shared rate limits + owner-aware buckets |
 | 2026-07-16 | 1.8.2 | P1-02 multi-worker job leases (SQLite claim, Redis fence, poller) |
 | 2026-07-16 | 1.8.3 | P1-03 scheduler leader election; fix claim-path unit tests |
+| 2026-07-16 | 1.8.4 | P1-12 Playwright e2e smoke CI; P1-14 OpenAPI contract tests |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -360,8 +360,10 @@ ruff format --check .
 ruff check .
 python -m coverage run -m unittest discover -v
 python -m coverage report
+# Optional browser smoke (needs: python -m playwright install chromium)
+RUN_E2E=1 python -m unittest discover -s e2e -v
 bandit -q -ll -r . \
-  -x ./.venv,./test_autonmap.py,./test_decrypt.py,./test_kali_ai_scan.py,./test_recon_planner.py,./test_scan_engine.py,./test_tool_inventory.py
+  -x ./.venv,./test_autonmap.py,./test_decrypt.py,./test_kali_ai_scan.py,./test_recon_planner.py,./test_scan_engine.py,./test_tool_inventory.py,./test_openapi_contract.py,./e2e
 pip-audit -r requirements.txt
 ```
 

--- a/autonmap.py
+++ b/autonmap.py
@@ -63,7 +63,7 @@ curl -H "X-API-KEY: $API_TOKEN" http://127.0.0.1:5000/jobs/<job_id>
 
 
 start_time = datetime.now(timezone.utc)
-VERSION = "1.8.3"
+VERSION = "1.8.4"
 SCAN_LOG_PATH = os.getenv("SCAN_LOG_PATH", "/app/logs/scan_log.txt")
 RESULTS_DIR = os.getenv("RESULTS_DIR", "encrypted_results")
 APP_HOST = os.getenv("APP_HOST", "127.0.0.1")

--- a/e2e/test_dashboard_smoke.py
+++ b/e2e/test_dashboard_smoke.py
@@ -1,0 +1,167 @@
+"""Browser smoke tests for the operator dashboard (Playwright).
+
+Run only in the CI e2e job (or locally with browsers installed):
+
+    RUN_E2E=1 python -m unittest discover -s e2e -v
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _wait_for_live(base_url: str, timeout: float = 30.0) -> None:
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/live", timeout=1.5) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+            last_error = exc
+            time.sleep(0.2)
+    raise TimeoutError(f"Server did not become live at {base_url}/live: {last_error}")
+
+
+@unittest.skipUnless(os.getenv("RUN_E2E") == "1", "Set RUN_E2E=1 to run Playwright smoke tests")
+class DashboardPlaywrightSmokeTests(unittest.TestCase):
+    server: subprocess.Popen | None = None
+    base_url: str = ""
+    tmpdir: tempfile.TemporaryDirectory | None = None
+    token: str = "e2e-browser-token-aaaaaaaa"
+    fernet: str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            from playwright.sync_api import sync_playwright  # noqa: F401
+        except ImportError as exc:
+            raise unittest.SkipTest(f"playwright not installed: {exc}") from exc
+
+        cls.tmpdir = tempfile.TemporaryDirectory(prefix="recon-e2e-")
+        port = _free_port()
+        cls.base_url = f"http://127.0.0.1:{port}"
+        env = os.environ.copy()
+        env.update(
+            {
+                "API_AUTH_REQUIRED": "true",
+                "API_AUTH_TOKEN": cls.token,
+                "FERNET_KEY": cls.fernet,
+                "APP_HOST": "127.0.0.1",
+                "APP_PORT": str(port),
+                "STATE_DB_PATH": str(Path(cls.tmpdir.name) / "state.db"),
+                "RESULTS_DIR": str(Path(cls.tmpdir.name) / "results"),
+                "SCAN_LOG_PATH": str(Path(cls.tmpdir.name) / "scan.log"),
+                "TELEGRAM_BOT_TOKEN": "",
+                "TELEGRAM_CHAT_ID": "",
+                "INITIAL_TASKS": "[]",
+            }
+        )
+        cls.server = subprocess.Popen(
+            [sys.executable, str(ROOT / "autonmap.py")],
+            cwd=str(ROOT),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            _wait_for_live(cls.base_url)
+        except Exception:
+            cls.tearDownClass()
+            raise
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.server is not None:
+            cls.server.terminate()
+            try:
+                cls.server.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                cls.server.kill()
+                cls.server.wait(timeout=5)
+            cls.server = None
+        if cls.tmpdir is not None:
+            cls.tmpdir.cleanup()
+            cls.tmpdir = None
+
+    def test_dashboard_loads_with_accessible_controls_and_nonce_csp(self):
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            page = browser.new_page()
+            response = page.goto(self.base_url + "/", wait_until="networkidle")
+            self.assertIsNotNone(response)
+            assert response is not None
+            self.assertEqual(response.status, 200)
+
+            title = page.title()
+            body = page.content()
+            self.assertIn("Recon Operator", body)
+            self.assertTrue(title == "Recon Operator" or "Recon" in body)
+
+            token = page.locator("#apiToken")
+            self.assertTrue(token.count() >= 1)
+            self.assertEqual(token.get_attribute("type"), "password")
+
+            # Focus ring / keyboard path: token field is focusable.
+            token.focus()
+            self.assertTrue(
+                page.evaluate("document.activeElement && document.activeElement.id === 'apiToken'")
+            )
+
+            key_meta = page.locator("#keyMeta")
+            self.assertTrue(key_meta.count() >= 1)
+
+            csp = response.headers.get("content-security-policy", "")
+            self.assertIn("nonce-", csp)
+            self.assertNotIn("unsafe-inline", csp)
+
+            # Authenticated whoami via page context (same-origin).
+            page.fill("#apiToken", self.token)
+            page.keyboard.press("Tab")
+            whoami = page.evaluate(
+                """async (token) => {
+                    const res = await fetch('/auth/whoami', {
+                        headers: { 'X-API-KEY': token }
+                    });
+                    return { status: res.status, body: await res.json() };
+                }""",
+                self.token,
+            )
+            self.assertEqual(whoami["status"], 200)
+            self.assertIn("key_id", whoami["body"])
+            self.assertIn("scopes", whoami["body"])
+
+            live = page.evaluate(
+                """async () => {
+                    const res = await fetch('/live');
+                    return { status: res.status, body: await res.json() };
+                }"""
+            )
+            self.assertEqual(live["status"], 200)
+            self.assertEqual(live["body"]["status"], "live")
+
+            browser.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@
 bandit==1.9.4
 coverage[toml]==7.15.0
 pip-audit==2.10.1
+playwright==1.61.0
 ruff==0.15.21

--- a/test_openapi_contract.py
+++ b/test_openapi_contract.py
@@ -1,0 +1,167 @@
+"""OpenAPI contract checks: schema shape and route parity with the Quart app."""
+
+from __future__ import annotations
+
+import os
+import re
+import unittest
+
+os.environ.setdefault("API_AUTH_REQUIRED", "true")
+os.environ.setdefault("API_AUTH_TOKEN", "test-token")
+os.environ.setdefault("FERNET_KEY", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+os.environ.setdefault("SCAN_LOG_PATH", "/tmp/nmap-automator-openapi.log")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "")
+os.environ.setdefault("STATE_DB_PATH", "/tmp/recon-operator-openapi.db")
+
+import autonmap
+
+
+def _normalize_rule(path: str) -> str:
+    """Convert Quart/Werkzeug rule to OpenAPI-style path template."""
+    # <path:task_id> or <job_id> -> {task_id} / {job_id}
+    return re.sub(r"<(?:path:)?([^>]+)>", r"{\1}", path)
+
+
+def _app_http_routes() -> set[tuple[str, str]]:
+    routes: set[tuple[str, str]] = set()
+    for rule in autonmap.app.url_map.iter_rules():
+        if rule.endpoint == "static":
+            continue
+        path = _normalize_rule(rule.rule)
+        for method in sorted(rule.methods or []):
+            if method in {"HEAD", "OPTIONS"}:
+                continue
+            routes.add((method.upper(), path))
+    return routes
+
+
+def _openapi_http_routes(spec: dict) -> set[tuple[str, str]]:
+    routes: set[tuple[str, str]] = set()
+    for path, item in (spec.get("paths") or {}).items():
+        if not isinstance(item, dict):
+            continue
+        for method, operation in item.items():
+            if method.startswith("x-") or not isinstance(operation, dict):
+                continue
+            if method.lower() not in {
+                "get",
+                "post",
+                "put",
+                "patch",
+                "delete",
+                "options",
+                "head",
+            }:
+                continue
+            routes.add((method.upper(), path))
+    return routes
+
+
+class OpenApiContractTests(unittest.IsolatedAsyncioTestCase):
+    def test_openapi_document_has_required_top_level_shape(self):
+        spec = autonmap.build_openapi_spec()
+        self.assertEqual(spec["openapi"], "3.0.3")
+        self.assertIn("info", spec)
+        self.assertEqual(spec["info"]["version"], autonmap.VERSION)
+        self.assertIn("paths", spec)
+        self.assertIn("components", spec)
+        self.assertIn("securitySchemes", spec["components"])
+        auth = spec["components"]["securitySchemes"]["ApiKeyAuth"]
+        self.assertEqual(auth["type"], "apiKey")
+        self.assertEqual(auth["in"], "header")
+        self.assertEqual(auth["name"], autonmap.API_AUTH_HEADER)
+
+    def test_critical_paths_exist_with_expected_methods(self):
+        spec = autonmap.build_openapi_spec()
+        paths = spec["paths"]
+        expected = {
+            "/live": {"get"},
+            "/ready": {"get"},
+            "/health": {"get"},
+            "/openapi.json": {"get"},
+            "/scan": {"post"},
+            "/jobs": {"get"},
+            "/jobs/{job_id}": {"get", "delete"},
+            "/schedule": {"post"},
+            "/tasks": {"get"},
+            "/tasks/{task_id}": {"delete"},
+            "/results": {"get"},
+            "/results/{result_id}": {"get"},
+            "/results/import": {"post"},
+            "/results/diff": {"post"},
+            "/tools": {"get"},
+            "/tools/ai-context": {"get"},
+            "/recon/plan": {"post"},
+            "/auth/whoami": {"get"},
+            "/": {"get"},
+            "/ui": {"get"},
+        }
+        for path, methods in expected.items():
+            self.assertIn(path, paths, f"missing path {path}")
+            for method in methods:
+                self.assertIn(method, paths[path], f"missing {method.upper()} {path}")
+                op = paths[path][method]
+                self.assertIn("responses", op)
+                self.assertTrue(op["responses"], f"no responses for {method} {path}")
+
+    def test_openapi_routes_match_registered_app_routes(self):
+        """Every documented OpenAPI operation must exist on the live Quart app."""
+        spec = autonmap.build_openapi_spec()
+        openapi_routes = _openapi_http_routes(spec)
+        app_routes = _app_http_routes()
+        missing_in_app = sorted(openapi_routes - app_routes)
+        self.assertEqual(
+            missing_in_app,
+            [],
+            f"OpenAPI documents routes not registered on the app: {missing_in_app}",
+        )
+
+    def test_authenticated_app_routes_are_documented(self):
+        """Core authenticated API surfaces should appear in OpenAPI."""
+        spec = autonmap.build_openapi_spec()
+        openapi_routes = _openapi_http_routes(spec)
+        required = {
+            ("POST", "/scan"),
+            ("GET", "/jobs"),
+            ("GET", "/jobs/{job_id}"),
+            ("DELETE", "/jobs/{job_id}"),
+            ("POST", "/schedule"),
+            ("GET", "/tasks"),
+            ("DELETE", "/tasks/{task_id}"),
+            ("GET", "/results"),
+            ("GET", "/results/{result_id}"),
+            ("POST", "/results/import"),
+            ("POST", "/results/diff"),
+            ("GET", "/tools"),
+            ("GET", "/tools/ai-context"),
+            ("POST", "/recon/plan"),
+            ("GET", "/auth/whoami"),
+            ("GET", "/live"),
+            ("GET", "/ready"),
+            ("GET", "/health"),
+            ("GET", "/openapi.json"),
+        }
+        missing = sorted(required - openapi_routes)
+        self.assertEqual(missing, [], f"Required API routes missing from OpenAPI: {missing}")
+
+    async def test_openapi_json_endpoint_matches_builder(self):
+        client = autonmap.app.test_client()
+        response = await client.get("/openapi.json")
+        payload = await response.get_json()
+        self.assertEqual(response.status_code, 200)
+        built = autonmap.build_openapi_spec()
+        self.assertEqual(payload["openapi"], built["openapi"])
+        self.assertEqual(set(payload["paths"]), set(built["paths"]))
+        self.assertEqual(payload["info"]["version"], autonmap.VERSION)
+
+    async def test_scan_request_schema_lists_supported_types(self):
+        spec = autonmap.build_openapi_spec()
+        scan_schema = spec["components"]["schemas"]["ScanRequest"]
+        enum_values = scan_schema["properties"]["scan_type"]["enum"]
+        for name in autonmap.SUPPORTED_SCAN_TYPES:
+            self.assertIn(name, enum_values)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- **P1-14:** OpenAPI contract tests (`test_openapi_contract.py`) — schema shape, critical paths, app route parity
- **P1-12:** Playwright dashboard smoke (`e2e/`) — CSP nonces, token field, whoami, `/live`
- CI: new `e2e` job (Chromium); unit matrix unchanged
- Version **1.8.4**

## Test plan
- [x] `python -m unittest discover` (124 pass)
- [x] coverage ≥ 75%
- [x] ruff clean
- [ ] CI unit + quality + e2e green