### PR TITLE
Recon Operator 1.8.5: axe-core a11y e2e

### DIFF
--- a/AUDIT_CHECKLIST.md
+++ b/AUDIT_CHECKLIST.md
@@ -180,7 +180,8 @@ Missing tools не устанавливались автоматически: э
 - [x] ~~Schedule multi-instance leader election (P1-03).~~
 - [ ] Full multi-tenant RBAC / UI accounts (token isolation only today).
 - [x] ~~Поднять `autonmap.py` coverage до ≥75% (~82%; overall ~78%; fail_under 75).~~
-- [x] ~~CI browser E2E (Playwright dashboard smoke).~~ axe-core still open.
+- [x] ~~CI browser E2E (Playwright dashboard smoke).~~
+- [x] ~~axe-core a11y + keyboard/ARIA/320px regression in e2e.~~
 - [x] ~~OpenAPI contract / route-parity tests.~~
 
 ### P2 — security и maintainability

--- a/IMPROVEMENT_PLAN.md
+++ b/IMPROVEMENT_PLAN.md
@@ -1,7 +1,7 @@
 # Recon Operator — полный план улучшений
 
 **Продукт:** Recon Operator (ранее Nmap Automator)  
-**Текущая версия кода:** 1.8.4  
+**Текущая версия кода:** 1.8.5  
 **Ветка:** `beta-hardening`  
 **Дата плана:** 2026-07-16  
 **Связанные файлы:** `AUDIT_CHECKLIST.md`, `README.md`, `SECURITY.md`
@@ -162,7 +162,7 @@
 | P1-10 | ~~Coverage `autonmap.py` ≥ 75%~~ | jobs, ownership, tools, planner, Telegram (~82%) | M |
 | P1-11 | ~~Overall coverage ≥ 75%, fail_under поднять~~ | `fail_under = 75` in pyproject (~78%) | S |
 | P1-12 | ~~Browser E2E в CI (Playwright)~~ | `e2e/` dashboard smoke + CI job | L |
-| P1-13 | axe-core / accessibility regression | keyboard, ARIA, contrast | M |
+| P1-13 | ~~axe-core / accessibility regression~~ | axe WCAG + keyboard/ARIA/320px (`e2e/test_dashboard_a11y.py`) | M |
 | P1-14 | ~~OpenAPI contract tests~~ | route parity + schema shape (`test_openapi_contract.py`) | M |
 
 **Критерий done P1:** 2+ API tokens с изоляцией; rate-limit корректный при 2 workers; coverage gate 75%; E2E smoke в CI.
@@ -410,6 +410,7 @@
 | 2026-07-16 | 1.8.2 | P1-02 multi-worker job leases (SQLite claim, Redis fence, poller) |
 | 2026-07-16 | 1.8.3 | P1-03 scheduler leader election; fix claim-path unit tests |
 | 2026-07-16 | 1.8.4 | P1-12 Playwright e2e smoke CI; P1-14 OpenAPI contract tests |
+| 2026-07-16 | 1.8.5 | P1-13 axe-core a11y + keyboard/ARIA/viewport e2e |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ ruff format --check .
 ruff check .
 python -m coverage run -m unittest discover -v
 python -m coverage report
-# Optional browser smoke (needs: python -m playwright install chromium)
+# Optional browser smoke + axe a11y (needs: python -m playwright install chromium)
 RUN_E2E=1 python -m unittest discover -s e2e -v
 bandit -q -ll -r . \
   -x ./.venv,./test_autonmap.py,./test_decrypt.py,./test_kali_ai_scan.py,./test_recon_planner.py,./test_scan_engine.py,./test_tool_inventory.py,./test_openapi_contract.py,./e2e

--- a/autonmap.py
+++ b/autonmap.py
@@ -63,7 +63,7 @@ curl -H "X-API-KEY: $API_TOKEN" http://127.0.0.1:5000/jobs/<job_id>
 
 
 start_time = datetime.now(timezone.utc)
-VERSION = "1.8.4"
+VERSION = "1.8.5"
 SCAN_LOG_PATH = os.getenv("SCAN_LOG_PATH", "/app/logs/scan_log.txt")
 RESULTS_DIR = os.getenv("RESULTS_DIR", "encrypted_results")
 APP_HOST = os.getenv("APP_HOST", "127.0.0.1")

--- a/e2e/helpers.py
+++ b/e2e/helpers.py
@@ -1,0 +1,96 @@
+"""Shared helpers for Playwright e2e suites."""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+DEFAULT_TOKEN = "e2e-browser-token-aaaaaaaa"
+DEFAULT_FERNET = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+
+def free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def wait_for_live(base_url: str, timeout: float = 30.0) -> None:
+    deadline = time.time() + timeout
+    last_error = None
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(f"{base_url}/live", timeout=1.5) as response:
+                if response.status == 200:
+                    return
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+            last_error = exc
+            time.sleep(0.2)
+    raise TimeoutError(f"Server did not become live at {base_url}/live: {last_error}")
+
+
+class DashboardServer:
+    """Start a local Recon Operator instance for browser tests."""
+
+    def __init__(self, token: str = DEFAULT_TOKEN, fernet: str = DEFAULT_FERNET) -> None:
+        self.token = token
+        self.fernet = fernet
+        self.base_url = ""
+        self._tmpdir: tempfile.TemporaryDirectory | None = None
+        self._server: subprocess.Popen | None = None
+
+    def start(self) -> str:
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="recon-e2e-")
+        port = free_port()
+        self.base_url = f"http://127.0.0.1:{port}"
+        env = os.environ.copy()
+        env.update(
+            {
+                "API_AUTH_REQUIRED": "true",
+                "API_AUTH_TOKEN": self.token,
+                "FERNET_KEY": self.fernet,
+                "APP_HOST": "127.0.0.1",
+                "APP_PORT": str(port),
+                "STATE_DB_PATH": str(Path(self._tmpdir.name) / "state.db"),
+                "RESULTS_DIR": str(Path(self._tmpdir.name) / "results"),
+                "SCAN_LOG_PATH": str(Path(self._tmpdir.name) / "scan.log"),
+                "TELEGRAM_BOT_TOKEN": "",
+                "TELEGRAM_CHAT_ID": "",
+                "INITIAL_TASKS": "[]",
+            }
+        )
+        self._server = subprocess.Popen(
+            [sys.executable, str(ROOT / "autonmap.py")],
+            cwd=str(ROOT),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            wait_for_live(self.base_url)
+        except Exception:
+            self.stop()
+            raise
+        return self.base_url
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.terminate()
+            try:
+                self._server.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                self._server.kill()
+                self._server.wait(timeout=5)
+            self._server = None
+        if self._tmpdir is not None:
+            self._tmpdir.cleanup()
+            self._tmpdir = None

--- a/e2e/test_dashboard_a11y.py
+++ b/e2e/test_dashboard_a11y.py
@@ -1,0 +1,140 @@
+"""axe-core accessibility regression for the operator dashboard.
+
+RUN_E2E=1 python -m unittest discover -s e2e -v
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from helpers import DashboardServer
+
+
+def _serious_violations(results) -> list[dict]:
+    """Return axe violations with serious/critical impact."""
+    violations = results.response.get("violations") or []
+    serious = []
+    for item in violations:
+        impact = (item.get("impact") or "").lower()
+        if impact in {"serious", "critical"}:
+            serious.append(item)
+    return serious
+
+
+def _format_violations(violations: list[dict]) -> str:
+    lines = []
+    for item in violations:
+        nodes = item.get("nodes") or []
+        targets = []
+        for node in nodes[:5]:
+            targets.extend(node.get("target") or [])
+        lines.append(
+            f"- {item.get('id')} ({item.get('impact')}): {item.get('help')} "
+            f"[{', '.join(targets) or 'no targets'}]"
+        )
+    return "\n".join(lines)
+
+
+@unittest.skipUnless(os.getenv("RUN_E2E") == "1", "Set RUN_E2E=1 to run Playwright a11y tests")
+class DashboardAxeAccessibilityTests(unittest.TestCase):
+    server: DashboardServer | None = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        try:
+            from axe_playwright_python.sync_playwright import Axe  # noqa: F401
+            from playwright.sync_api import sync_playwright  # noqa: F401
+        except ImportError as exc:
+            raise unittest.SkipTest(f"playwright/axe not installed: {exc}") from exc
+
+        cls.server = DashboardServer()
+        cls.server.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.server is not None:
+            cls.server.stop()
+            cls.server = None
+
+    def test_dashboard_has_no_serious_axe_violations(self):
+        from axe_playwright_python.sync_playwright import Axe
+        from playwright.sync_api import sync_playwright
+
+        assert self.server is not None
+        options = {
+            "runOnly": {
+                "type": "tag",
+                "values": ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
+            },
+            "resultTypes": ["violations"],
+        }
+
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            page = browser.new_page()
+            response = page.goto(self.server.base_url + "/", wait_until="networkidle")
+            self.assertIsNotNone(response)
+            assert response is not None
+            self.assertEqual(response.status, 200)
+
+            results = Axe().run(page, options=options)
+            serious = _serious_violations(results)
+            self.assertEqual(
+                serious,
+                [],
+                "Serious/critical axe-core violations:\n" + _format_violations(serious),
+            )
+            browser.close()
+
+    def test_keyboard_and_aria_structure(self):
+        from playwright.sync_api import sync_playwright
+
+        assert self.server is not None
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.set_viewport_size({"width": 1280, "height": 900})
+            page.goto(self.server.base_url + "/", wait_until="networkidle")
+
+            # Landmark / live region semantics used by the operator UI.
+            self.assertGreaterEqual(page.locator('[role="status"]').count(), 1)
+            self.assertGreaterEqual(page.locator('[role="tablist"]').count(), 1)
+            tabs = page.locator('[role="tab"]')
+            self.assertGreaterEqual(tabs.count(), 4)
+            self.assertEqual(page.locator('[role="tab"][aria-selected="true"]').count(), 1)
+
+            # Keyboard: Tab reaches primary controls; Enter activates a tab.
+            page.locator("#apiToken").focus()
+            page.keyboard.press("Tab")
+            # Walk a few tabs to ensure no focus trap on the control panel.
+            for _ in range(8):
+                page.keyboard.press("Tab")
+            active_tag = page.evaluate(
+                "document.activeElement ? document.activeElement.tagName : ''"
+            )
+            self.assertIn(active_tag, {"INPUT", "BUTTON", "SELECT", "TEXTAREA", "A"})
+
+            # Switch result view via keyboard-activated tab button.
+            json_tab = page.locator('[role="tab"][data-view="json"]')
+            json_tab.focus()
+            page.keyboard.press("Enter")
+            self.assertEqual(json_tab.get_attribute("aria-selected"), "true")
+
+            # Narrow viewport regression: no horizontal overflow at 320px.
+            page.set_viewport_size({"width": 320, "height": 720})
+            page.wait_for_timeout(100)
+            overflow = page.evaluate(
+                "() => ({ sw: document.documentElement.scrollWidth, cw: document.documentElement.clientWidth })"
+            )
+            self.assertLessEqual(
+                overflow["sw"],
+                overflow["cw"] + 1,
+                f"horizontal overflow at 320px: scrollWidth={overflow['sw']} clientWidth={overflow['cw']}",
+            )
+
+            browser.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/e2e/test_dashboard_smoke.py
+++ b/e2e/test_dashboard_smoke.py
@@ -8,46 +8,14 @@ Run only in the CI e2e job (or locally with browsers installed):
 from __future__ import annotations
 
 import os
-import socket
-import subprocess
-import sys
-import tempfile
-import time
 import unittest
-import urllib.error
-import urllib.request
-from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[1]
-
-
-def _free_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-        sock.bind(("127.0.0.1", 0))
-        return int(sock.getsockname()[1])
-
-
-def _wait_for_live(base_url: str, timeout: float = 30.0) -> None:
-    deadline = time.time() + timeout
-    last_error = None
-    while time.time() < deadline:
-        try:
-            with urllib.request.urlopen(f"{base_url}/live", timeout=1.5) as response:
-                if response.status == 200:
-                    return
-        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
-            last_error = exc
-            time.sleep(0.2)
-    raise TimeoutError(f"Server did not become live at {base_url}/live: {last_error}")
+from helpers import DashboardServer
 
 
 @unittest.skipUnless(os.getenv("RUN_E2E") == "1", "Set RUN_E2E=1 to run Playwright smoke tests")
 class DashboardPlaywrightSmokeTests(unittest.TestCase):
-    server: subprocess.Popen | None = None
-    base_url: str = ""
-    tmpdir: tempfile.TemporaryDirectory | None = None
-    token: str = "e2e-browser-token-aaaaaaaa"
-    fernet: str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+    server: DashboardServer | None = None
 
     @classmethod
     def setUpClass(cls) -> None:
@@ -56,67 +24,29 @@ class DashboardPlaywrightSmokeTests(unittest.TestCase):
         except ImportError as exc:
             raise unittest.SkipTest(f"playwright not installed: {exc}") from exc
 
-        cls.tmpdir = tempfile.TemporaryDirectory(prefix="recon-e2e-")
-        port = _free_port()
-        cls.base_url = f"http://127.0.0.1:{port}"
-        env = os.environ.copy()
-        env.update(
-            {
-                "API_AUTH_REQUIRED": "true",
-                "API_AUTH_TOKEN": cls.token,
-                "FERNET_KEY": cls.fernet,
-                "APP_HOST": "127.0.0.1",
-                "APP_PORT": str(port),
-                "STATE_DB_PATH": str(Path(cls.tmpdir.name) / "state.db"),
-                "RESULTS_DIR": str(Path(cls.tmpdir.name) / "results"),
-                "SCAN_LOG_PATH": str(Path(cls.tmpdir.name) / "scan.log"),
-                "TELEGRAM_BOT_TOKEN": "",
-                "TELEGRAM_CHAT_ID": "",
-                "INITIAL_TASKS": "[]",
-            }
-        )
-        cls.server = subprocess.Popen(
-            [sys.executable, str(ROOT / "autonmap.py")],
-            cwd=str(ROOT),
-            env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        try:
-            _wait_for_live(cls.base_url)
-        except Exception:
-            cls.tearDownClass()
-            raise
+        cls.server = DashboardServer()
+        cls.server.start()
 
     @classmethod
     def tearDownClass(cls) -> None:
         if cls.server is not None:
-            cls.server.terminate()
-            try:
-                cls.server.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                cls.server.kill()
-                cls.server.wait(timeout=5)
+            cls.server.stop()
             cls.server = None
-        if cls.tmpdir is not None:
-            cls.tmpdir.cleanup()
-            cls.tmpdir = None
 
     def test_dashboard_loads_with_accessible_controls_and_nonce_csp(self):
         from playwright.sync_api import sync_playwright
 
+        assert self.server is not None
         with sync_playwright() as playwright:
             browser = playwright.chromium.launch(headless=True)
             page = browser.new_page()
-            response = page.goto(self.base_url + "/", wait_until="networkidle")
+            response = page.goto(self.server.base_url + "/", wait_until="networkidle")
             self.assertIsNotNone(response)
             assert response is not None
             self.assertEqual(response.status, 200)
 
-            title = page.title()
             body = page.content()
             self.assertIn("Recon Operator", body)
-            self.assertTrue(title == "Recon Operator" or "Recon" in body)
 
             token = page.locator("#apiToken")
             self.assertTrue(token.count() >= 1)
@@ -135,8 +65,7 @@ class DashboardPlaywrightSmokeTests(unittest.TestCase):
             self.assertIn("nonce-", csp)
             self.assertNotIn("unsafe-inline", csp)
 
-            # Authenticated whoami via page context (same-origin).
-            page.fill("#apiToken", self.token)
+            page.fill("#apiToken", self.server.token)
             page.keyboard.press("Tab")
             whoami = page.evaluate(
                 """async (token) => {
@@ -145,7 +74,7 @@ class DashboardPlaywrightSmokeTests(unittest.TestCase):
                     });
                     return { status: res.status, body: await res.json() };
                 }""",
-                self.token,
+                self.server.token,
             )
             self.assertEqual(whoami["status"], 200)
             self.assertIn("key_id", whoami["body"])

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 
+axe-playwright-python==0.1.7
 bandit==1.9.4
 coverage[toml]==7.15.0
 pip-audit==2.10.1


### PR DESCRIPTION
## Summary
- **P1-13:** axe-core WCAG2/2.1 A/AA serious+critical violations fail the e2e job
- Keyboard focus walk + ARIA tablist/tab selection
- 320px viewport overflow guard
- Shared `e2e/helpers.py` server harness for smoke + a11y

## Test plan
- [x] unit tests pass
- [x] `RUN_E2E=1 python -m unittest discover -s e2e -v` (3 tests OK locally)
- [ ] CI e2e/quality/test green